### PR TITLE
STEP4) 같은 사용자가 동일한 특강에 대해 신청 성공하지 못하도록 개선

### DIFF
--- a/src/enrollment/infrastructure/enrollment.repository.ts
+++ b/src/enrollment/infrastructure/enrollment.repository.ts
@@ -32,6 +32,17 @@ export class EnrollmentRepository
       if (schedule.currentEnrollmentCount >= schedule.enrollmentCapacity) {
         throw new BadRequestException('Schedule is full');
       }
+
+      // enrollment에 대한 비관적 락 설정
+      const existingEnrollment = await manager.findOne(Enrollment, {
+        where: { userId: enrollment.userId, scheduleId: enrollment.scheduleId },
+        lock: { mode: 'pessimistic_read' },
+      });
+
+      if (existingEnrollment) {
+        throw new BadRequestException('Enrollment already exists');
+      }
+
       // 수강 인원 증가 및 상태 업데이트
       schedule.currentEnrollmentCount += 1;
       await manager.save(schedule);


### PR DESCRIPTION

### 과정

- 동일한 유저 정보로 같은 특강을 5번 신청했을 때, 1번만 성공하는 것을 검증하는 통합 테스트 작성
67801a98892764b9486c4e0f6e2da06564c5e77e

- 비관적락 중 읽기 락으로 해결했습니다
   enrollment에 pessimistic_read로 설정하여 첫번째 요청만 enrollment를 읽을 수 있고
   첫번째 요청이 enrollment를 읽는 동안 다른 요청은 쓰기를 못하니 대기하다가
   중복로직에 걸리도록 해서 해결했습니다
   
   
 ### 과제를 마치고 아쉬움...
진짜 갑자기 transaction 부분 해결하면서 제 나름대로 깔끔하게 해놨던 코드들이
점점 유지보수 어려워진듯한 느낌을 보면서 transaction decorator로 깔끔하게 해결하고 싶다는 생각을 하게되었습니다

그리고 시간 배분을 앞으로는 더 해야겠습니다 이번에는 맨땅에 프로젝트 만드는 거라 이것까지 고려하고
시간 분배했어야 했는데 그러지 못했습니다
 